### PR TITLE
[FEAT]: manual registration endpoint

### DIFF
--- a/src/main/java/io/github/webbasedwodt/adapter/BasePlatformManagementInterface.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/BasePlatformManagementInterface.java
@@ -59,7 +59,7 @@ final class BasePlatformManagementInterface implements PlatformManagementInterfa
                     .join()
                     .statusCode() == ACCEPTED_REQUEST_STATUS_CODE;
             if (status) {
-                this.platforms.add(platformUrl);
+                notifyNewRegistration(platformUrl);
             }
             return status;
         } else {
@@ -92,5 +92,10 @@ final class BasePlatformManagementInterface implements PlatformManagementInterfa
     @Override
     public Set<URI> getRegisteredPlatformUrls() {
         return new HashSet<>(this.platforms);
+    }
+
+    @Override
+    public boolean notifyNewRegistration(final URI platformUrl) {
+        return this.platforms.add(platformUrl);
     }
 }

--- a/src/main/java/io/github/webbasedwodt/adapter/BasePlatformManagementInterface.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/BasePlatformManagementInterface.java
@@ -35,7 +35,7 @@ final class BasePlatformManagementInterface implements PlatformManagementInterfa
     private static final String PATH_TO_PLATFORM_WODT = "/wodt";
     private static final int ACCEPTED_REQUEST_STATUS_CODE = 202;
     private final String digitalTwinUri;
-    private final Set<String> platforms;
+    private final Set<URI> platforms;
 
     /**
      * Default constructor.
@@ -47,7 +47,7 @@ final class BasePlatformManagementInterface implements PlatformManagementInterfa
     }
 
     @Override
-    public boolean registerToPlatform(final String platformUrl, final String currentDtd) {
+    public boolean registerToPlatform(final URI platformUrl, final String currentDtd) {
         if (!this.platforms.contains(platformUrl)) {
             final HttpClient httpClient = HttpClient.newHttpClient();
             final HttpRequest httpRequest = HttpRequest.newBuilder()
@@ -77,13 +77,20 @@ final class BasePlatformManagementInterface implements PlatformManagementInterfa
                     .build();
             httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString());
         });
+        this.platforms.clear();
     }
 
-    private URI getPlatformWoDT(final String platformUrl, final String... path) {
-        String platformWoDT = platformUrl.concat(PATH_TO_PLATFORM_WODT);
+    private URI getPlatformWoDT(final URI platformUrl, final String... path) {
+        final String platformUrlString = platformUrl.toString();
+        String platformWoDT = platformUrlString.concat(PATH_TO_PLATFORM_WODT);
         if (path.length > 0) {
-            platformWoDT = platformUrl.concat(Arrays.stream(path).collect(Collectors.joining("/", "/", "")));
+            platformWoDT = platformUrlString.concat(Arrays.stream(path).collect(Collectors.joining("/", "/", "")));
         }
         return URI.create(platformWoDT);
+    }
+
+    @Override
+    public Set<URI> getRegisteredPlatformUrls() {
+        return new HashSet<>(this.platforms);
     }
 }

--- a/src/main/java/io/github/webbasedwodt/adapter/PlatformManagementInterfaceAPIControllerImpl.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/PlatformManagementInterfaceAPIControllerImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.adapter;
+
+import io.github.webbasedwodt.application.component.PlatformManagementInterfaceAPIController;
+import io.github.webbasedwodt.application.component.PlatformManagementInterfaceNotifier;
+import io.github.webbasedwodt.application.presenter.api.PlatformRegistration;
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+
+import java.net.URI;
+
+/**
+ * Implementation of the controller for the Platform Management Interface API.
+ */
+final class PlatformManagementInterfaceAPIControllerImpl implements PlatformManagementInterfaceAPIController {
+    private final PlatformManagementInterfaceNotifier platformManagementInterfaceNotifier;
+
+    /**
+     * Default constructor.
+     * @param platformManagementInterfaceNotifier the platform management interface notifier that handle registrations
+     */
+    PlatformManagementInterfaceAPIControllerImpl(
+            final PlatformManagementInterfaceNotifier platformManagementInterfaceNotifier
+    ) {
+        this.platformManagementInterfaceNotifier = platformManagementInterfaceNotifier;
+    }
+
+
+    @Override
+    public void routeNewRegistration(final Context context) {
+        try {
+            final PlatformRegistration platformRegistration = context.bodyAsClass(PlatformRegistration.class);
+            if (platformRegistration.getSelf() != null
+                && this.platformManagementInterfaceNotifier.notifyNewRegistration(
+                        URI.create(platformRegistration.getSelf()))
+            ) {
+                context.status(HttpStatus.OK);
+            } else {
+                context.status(HttpStatus.BAD_REQUEST);
+            }
+        } catch (final IllegalArgumentException exception) {
+            context.status(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Override
+    public void registerRoutes(final Javalin app) {
+        app.post("/platform", this::routeNewRegistration);
+    }
+}

--- a/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapter.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapter.java
@@ -76,7 +76,9 @@ public final class WoDTDigitalAdapter extends DigitalAdapter<WoDTDigitalAdapterC
                                 .info("Impossible to forward action: " + e);
                         return false;
                     }
-                });
+                },
+                this.platformManagementInterface
+        );
     }
 
     @Override

--- a/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapter.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapter.java
@@ -53,12 +53,15 @@ public final class WoDTDigitalAdapter extends DigitalAdapter<WoDTDigitalAdapterC
      */
     public WoDTDigitalAdapter(final String digitalAdapterId, final WoDTDigitalAdapterConfiguration configuration) {
         super(digitalAdapterId, configuration);
+        this.platformManagementInterface = new BasePlatformManagementInterface(
+                this.getConfiguration().getDigitalTwinUri());
         this.dtkgEngine = new JenaDTKGEngine(this.getConfiguration().getDigitalTwinUri());
         this.dtdManager = new WoTDTDManager(
                 this.getConfiguration().getDigitalTwinUri(),
                 this.getConfiguration().getOntology(),
                 this.getConfiguration().getPhysicalAssetId(),
-                this.getConfiguration().getPortNumber()
+                this.getConfiguration().getPortNumber(),
+                this.platformManagementInterface
         );
         this.woDTWebServer = new WoDTWebServerImpl(
                 this.getConfiguration().getPortNumber(),
@@ -74,8 +77,6 @@ public final class WoDTDigitalAdapter extends DigitalAdapter<WoDTDigitalAdapterC
                         return false;
                     }
                 });
-        this.platformManagementInterface = new BasePlatformManagementInterface(
-                this.getConfiguration().getDigitalTwinUri());
     }
 
     @Override
@@ -222,11 +223,8 @@ public final class WoDTDigitalAdapter extends DigitalAdapter<WoDTDigitalAdapterC
     @Override
     public void onAdapterStart() {
         this.woDTWebServer.start();
-        this.getConfiguration().getPlatformToRegister().forEach(platform -> {
-            if (this.platformManagementInterface.registerToPlatform(platform, this.dtdManager.getDTD().toJson())) {
-                this.dtdManager.addPlatform(platform);
-            }
-        });
+        this.getConfiguration().getPlatformToRegister().forEach(platform ->
+                this.platformManagementInterface.registerToPlatform(platform, this.dtdManager.getDTD().toJson()));
     }
 
     @Override

--- a/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapterConfiguration.java
+++ b/src/main/java/io/github/webbasedwodt/adapter/WoDTDigitalAdapterConfiguration.java
@@ -18,6 +18,7 @@ package io.github.webbasedwodt.adapter;
 
 import io.github.webbasedwodt.model.ontology.DTOntology;
 
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +30,7 @@ public final class WoDTDigitalAdapterConfiguration {
     private final String digitalTwinUri;
     private final int portNumber;
     private final String physicalAssetId;
-    private final Set<String> platformToRegister;
+    private final Set<URI> platformToRegister;
 
     /**
      * Default constructor.
@@ -44,7 +45,7 @@ public final class WoDTDigitalAdapterConfiguration {
             final DTOntology ontology,
             final int portNumber,
             final String physicalAssetId,
-            final Set<String> platformToRegister) {
+            final Set<URI> platformToRegister) {
         this.digitalTwinUri = digitalTwinUri;
         this.ontology = ontology;
         this.portNumber = portNumber;
@@ -88,7 +89,7 @@ public final class WoDTDigitalAdapterConfiguration {
      * Obtain the platform to which register.
      * @return the platforms urls.
      */
-    public Set<String> getPlatformToRegister() {
+    public Set<URI> getPlatformToRegister() {
         return new HashSet<>(this.platformToRegister);
     }
 }

--- a/src/main/java/io/github/webbasedwodt/application/component/DTDManager.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/DTDManager.java
@@ -58,11 +58,4 @@ public interface DTDManager extends DTDManagerReader {
      * @return true is correctly removed, false if not present
      */
     boolean removeAction(String rawActionName);
-
-    /**
-     * Add a WoDT Digital Twins Platform to which the WoDT Digital Twin is registered, to the DTD.
-     * @param platformUrl the url of the WoDT Digital Twins Platform
-     * @return true is correctly added, false instead
-     */
-    boolean addPlatform(String platformUrl);
 }

--- a/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterface.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterface.java
@@ -21,7 +21,8 @@ import java.net.URI;
 /**
  * This interface represent the PlatformManagementInterface component in the Abstract Architecture.
  */
-public interface PlatformManagementInterface extends PlatformManagementInterfaceReader {
+public interface PlatformManagementInterface extends
+        PlatformManagementInterfaceReader, PlatformManagementInterfaceNotifier {
     /**
      * This method allows the component to send the registration request to the passed WoDT Digital Twins Platform.
      * @param platformUrl the platformUrl to which register

--- a/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterface.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterface.java
@@ -16,17 +16,19 @@
 
 package io.github.webbasedwodt.application.component;
 
+import java.net.URI;
+
 /**
  * This interface represent the PlatformManagementInterface component in the Abstract Architecture.
  */
-public interface PlatformManagementInterface {
+public interface PlatformManagementInterface extends PlatformManagementInterfaceReader {
     /**
      * This method allows the component to send the registration request to the passed WoDT Digital Twins Platform.
      * @param platformUrl the platformUrl to which register
      * @param currentDtd the current Digital Twin Descriptor
      * @return true if correctly registered, false instead
      */
-    boolean registerToPlatform(String platformUrl, String currentDtd);
+    boolean registerToPlatform(URI platformUrl, String currentDtd);
 
     /**
      * Signal to the Platform Management Interface the deletion of the managed Digital Twin.

--- a/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceAPIController.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceAPIController.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.application.component;
+
+import io.javalin.http.Context;
+
+/**
+ * This interface represents the Platform Management Interface controller for the exposed APIs.
+ */
+public interface PlatformManagementInterfaceAPIController extends WebServerController {
+    /**
+     * Notify registration to a new Platform.
+     * @param context the javalin context
+     */
+    void routeNewRegistration(Context context);
+}

--- a/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceNotifier.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceNotifier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.application.component;
+
+import java.net.URI;
+
+/**
+ * This interface models the notifier part of the Platform Management Interface that get notified when a
+ * Platform has added the DT to its ecosystem.
+ */
+public interface PlatformManagementInterfaceNotifier {
+    /**
+     * Notify the registration to a new Platform.
+     * @param platformUrl the url of the platform that has added the DT.
+     * @return true if the DT platform was not already registered, false instead.
+     */
+    boolean notifyNewRegistration(URI platformUrl);
+}

--- a/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceReader.java
+++ b/src/main/java/io/github/webbasedwodt/application/component/PlatformManagementInterfaceReader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.application.component;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * This interface represent the reader part of the PlatformManagementInterface component of the Abstract Architecture.
+ */
+public interface PlatformManagementInterfaceReader {
+    /**
+     * This method allows to obtain all the Platform URLs to which the DT is registered.
+     * @return the set of urls.
+     */
+    Set<URI> getRegisteredPlatformUrls();
+}

--- a/src/main/java/io/github/webbasedwodt/application/presenter/api/PlatformRegistration.java
+++ b/src/main/java/io/github/webbasedwodt/application/presenter/api/PlatformRegistration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.application.presenter.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Presenter class to be able to deserialize platform registration data from the API.
+ * It contains the self field where the WoDT Digital Twins Platform send its URL.
+ */
+public final class PlatformRegistration {
+    private final String self;
+
+    /**
+     * Default constructor.
+     * @param self the field where the WoDT Platform send its URL
+     */
+    @JsonCreator
+    public PlatformRegistration(@JsonProperty("self") final String self) {
+        this.self = self;
+    }
+
+    /**
+     * Obtain the url of the Platform that added the DT.
+     * @return the Platform url
+     */
+    public String getSelf() {
+        return this.self;
+    }
+}

--- a/src/test/java/io/github/webbasedwodt/adapter/WoDTDigitalTwinInterfaceControllerTest.java
+++ b/src/test/java/io/github/webbasedwodt/adapter/WoDTDigitalTwinInterfaceControllerTest.java
@@ -16,6 +16,7 @@
 
 package io.github.webbasedwodt.adapter;
 
+import io.github.webbasedwodt.adapter.testdouble.PlatformManagementInterfaceReaderTestDouble;
 import io.github.webbasedwodt.application.component.DTDManager;
 import io.github.webbasedwodt.application.component.DTKGEngine;
 import io.github.webbasedwodt.integration.wldt.LampDTOntology;
@@ -51,7 +52,8 @@ class WoDTDigitalTwinInterfaceControllerTest {
                 TEST_DIGITAL_TWIN_URI,
                 new LampDTOntology(),
                 "lampPA",
-                TEST_PORT_NUMBER);
+                TEST_PORT_NUMBER,
+                new PlatformManagementInterfaceReaderTestDouble());
         new WoDTDigitalTwinInterfaceControllerImpl(this.dtkgEngine, this.dtdManager, (action, body) -> true)
                 .registerRoutes(this.app);
     }

--- a/src/test/java/io/github/webbasedwodt/adapter/WoTDTDManagerTest.java
+++ b/src/test/java/io/github/webbasedwodt/adapter/WoTDTDManagerTest.java
@@ -17,6 +17,7 @@
 package io.github.webbasedwodt.adapter;
 
 import io.github.sanecity.wot.thing.Thing;
+import io.github.webbasedwodt.adapter.testdouble.PlatformManagementInterfaceReaderTestDouble;
 import io.github.webbasedwodt.application.component.DTDManager;
 import io.github.webbasedwodt.integration.wldt.LampDTOntology;
 import io.github.webbasedwodt.model.ontology.DTOntology;
@@ -47,7 +48,8 @@ class WoTDTDManagerTest {
                 "http://example/dt",
                 this.lampOntology,
                 "lampPA",
-                TEST_PORT_NUMBER);
+                TEST_PORT_NUMBER,
+                new PlatformManagementInterfaceReaderTestDouble());
     }
 
     @Test
@@ -123,10 +125,9 @@ class WoTDTDManagerTest {
     }
 
     @Test
-    @DisplayName("It should be possible to add a Platform to which it is registered")
+    @DisplayName("The DTDManager should be able to obtain the Platforms to which it is registered and link "
+            + "them to the descriptor")
     void addPlatform() {
-        final String platformUrl = "http://platform.it";
-        this.dtdManager.addPlatform(platformUrl);
         final Thing<?, ?, ?> thingDescription = this.dtdManager.getDTD();
         assertTrue(thingDescription.getMetadata().containsKey("links"));
         assertEquals(1, ((List<?>) thingDescription.getMetadata("links")).size());

--- a/src/test/java/io/github/webbasedwodt/adapter/testdouble/PlatformManagementInterfaceReaderTestDouble.java
+++ b/src/test/java/io/github/webbasedwodt/adapter/testdouble/PlatformManagementInterfaceReaderTestDouble.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024. Andrea Giulianelli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.webbasedwodt.adapter.testdouble;
+
+import io.github.webbasedwodt.application.component.PlatformManagementInterfaceReader;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * A {@link io.github.webbasedwodt.application.component.PlatformManagementInterfaceReader} test double that provides
+ * a single platform with URI 'http://platform.it'.
+ */
+public final class PlatformManagementInterfaceReaderTestDouble implements PlatformManagementInterfaceReader {
+    @Override
+    public Set<URI> getRegisteredPlatformUrls() {
+        return Set.of(URI.create("http://platform.it"));
+    }
+}

--- a/src/test/java/io/github/webbasedwodt/integration/wldt/LampDT.java
+++ b/src/test/java/io/github/webbasedwodt/integration/wldt/LampDT.java
@@ -28,6 +28,7 @@ import it.wldt.exception.WldtEngineException;
 import it.wldt.exception.WldtRuntimeException;
 import it.wldt.exception.WldtWorkerException;
 
+import java.net.URI;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -57,7 +58,7 @@ public final class LampDT {
                             new LampDTOntology(),
                             TEST_PORT_NUMBER,
                             "lampPA",
-                            Set.of())
+                            Set.of(URI.create("http://localhost:4000")))
             ));
 
             final DigitalTwinEngine digitalTwinEngine = new DigitalTwinEngine();

--- a/src/test/java/io/github/webbasedwodt/integration/wldt/LampDT.java
+++ b/src/test/java/io/github/webbasedwodt/integration/wldt/LampDT.java
@@ -28,7 +28,6 @@ import it.wldt.exception.WldtEngineException;
 import it.wldt.exception.WldtRuntimeException;
 import it.wldt.exception.WldtWorkerException;
 
-import java.net.URI;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -54,11 +53,11 @@ public final class LampDT {
             digitalTwin.addDigitalAdapter(new WoDTDigitalAdapter(
                     "wodt-dt-adapter",
                     new WoDTDigitalAdapterConfiguration(
-                            "https://example.com/dt",
+                            "http://localhost:" + TEST_PORT_NUMBER,
                             new LampDTOntology(),
                             TEST_PORT_NUMBER,
                             "lampPA",
-                            Set.of(URI.create("http://localhost:4000")))
+                            Set.of())
             ));
 
             final DigitalTwinEngine digitalTwinEngine = new DigitalTwinEngine();


### PR DESCRIPTION
Add endpoint to notify the manual DT registration to a Platform.
For the moment, use a fixed endpoint: `/platform` that receives the following JSON data in the body (below an example platform uri):
```json
{
   "self": "http://platform-uri.it"
}
```

Further work is necessary to make the endpoint automatically discoverable by the Platform and so machine-readable, or strictly defined at the spec level.
